### PR TITLE
Move `sample_with_seed` to `Sample` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+- **breaking:** moved `sample_with_seed` to `Sample` trait
+- **breaking:** moved `sample` to `Noise` trait
+- **breaking:** removed `SampleWithSeed` trait
+
 ## 0.7.0 (2025-01-19)
 - **breaking:** sealed the `OpenSimplexNoise` trait
 - **breaking:** changed `OpenSimplex2` 2D and 3D implementation and output

--- a/src/base.rs
+++ b/src/base.rs
@@ -44,13 +44,6 @@ macro_rules! impl_noise {
         $crate::base::if_has_dim! { 2 in $dims;
             impl $crate::Sample<2> for $struct {
                 #[inline(always)]
-                fn sample(&self, point: [f32; 2]) -> f32 {
-                    self.gen2(point, 0)
-                }
-            }
-
-            impl $crate::SampleWithSeed<2> for $struct {
-                #[inline(always)]
                 fn sample_with_seed(&self, point: [f32; 2], seed: i32) -> f32 {
                     self.gen2(point, seed)
                 }
@@ -58,14 +51,6 @@ macro_rules! impl_noise {
 
             #[cfg(feature = "nightly-simd")]
             impl $crate::Sample<2, core::simd::f32x2> for $struct {
-                #[inline(always)]
-                fn sample(&self, point: core::simd::f32x2) -> f32 {
-                    self.gen2a(point, 0)
-                }
-            }
-
-            #[cfg(feature = "nightly-simd")]
-            impl $crate::SampleWithSeed<2, core::simd::f32x2> for $struct {
                 #[inline(always)]
                 fn sample_with_seed(&self, point: core::simd::f32x2, seed: i32) -> f32 {
                     self.gen2a(point, seed)
@@ -76,13 +61,6 @@ macro_rules! impl_noise {
         $crate::base::if_has_dim! { 3 in $dims;
             impl $crate::Sample<3> for $struct {
                 #[inline(always)]
-                fn sample(&self, point: [f32; 3]) -> f32 {
-                    self.gen3(point, 0)
-                }
-            }
-
-            impl $crate::SampleWithSeed<3> for $struct {
-                #[inline(always)]
                 fn sample_with_seed(&self, point: [f32; 3], seed: i32) -> f32 {
                     self.gen3(point, seed)
                 }
@@ -90,14 +68,6 @@ macro_rules! impl_noise {
 
             #[cfg(feature = "nightly-simd")]
             impl $crate::Sample<3, core::simd::f32x4> for $struct {
-                #[inline(always)]
-                fn sample(&self, point: core::simd::f32x4) -> f32 {
-                    self.gen3a(point, 0)
-                }
-            }
-
-            #[cfg(feature = "nightly-simd")]
-            impl $crate::SampleWithSeed<3, core::simd::f32x4> for $struct {
                 #[inline(always)]
                 fn sample_with_seed(&self, point: core::simd::f32x4, seed: i32) -> f32 {
                     self.gen3a(point, seed)
@@ -108,13 +78,6 @@ macro_rules! impl_noise {
         $crate::base::if_has_dim! { 4 in $dims;
             impl $crate::Sample<4> for $struct {
                 #[inline(always)]
-                fn sample(&self, point: [f32; 4]) -> f32 {
-                    self.gen4(point, 0)
-                }
-            }
-
-            impl $crate::SampleWithSeed<4> for $struct {
-                #[inline(always)]
                 fn sample_with_seed(&self, point: [f32; 4], seed: i32) -> f32 {
                     self.gen4(point, seed)
                 }
@@ -122,14 +85,6 @@ macro_rules! impl_noise {
 
             #[cfg(feature = "nightly-simd")]
             impl $crate::Sample<4, core::simd::f32x4> for $struct {
-                #[inline(always)]
-                fn sample(&self, point: core::simd::f32x4) -> f32 {
-                    self.gen4a(point, 0)
-                }
-            }
-
-            #[cfg(feature = "nightly-simd")]
-            impl $crate::SampleWithSeed<4, core::simd::f32x4> for $struct {
                 #[inline(always)]
                 fn sample_with_seed(&self, point: core::simd::f32x4, seed: i32) -> f32 {
                     self.gen4a(point, seed)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub use base::{CellDistance, CellDistanceSq, CellValue, OpenSimplex2, OpenSimple
 pub use noise::Noise;
 pub use noise_fn::NoiseFn;
 pub use open_simplex_2::OpenSimplexNoise;
-pub use sample::{Sample, Sample2, Sample3, Sample4, SampleWithSeed};
+pub use sample::{Sample, Sample2, Sample3, Sample4};
 #[cfg(feature = "nightly-simd")]
 pub use sample::{Sample2a, Sample3a, Sample4a};
 

--- a/src/modifiers.rs
+++ b/src/modifiers.rs
@@ -58,7 +58,7 @@ macro_rules! modifier_map {
         }
 
         const _: () = {
-            use crate::{ Noise, Sample, SampleWithSeed };
+            use crate::{ Noise, Sample };
 
             #[cfg(feature = "nightly-simd")]
             use core::simd::{ Simd, LaneCount, SupportedLaneCount };
@@ -67,18 +67,7 @@ macro_rules! modifier_map {
 
             impl<Noise, const DIM: usize> Sample<DIM> for $struct<Noise>
             where
-                Noise: SampleWithSeed<DIM>,
-            {
-                #[inline]
-                fn sample(&$self, $point: [f32; DIM]) -> f32 {
-                    let $value = $self.noise.sample($point);
-                    or_else!({$({$($map_value)*})?} else { $value })
-                }
-            }
-
-            impl<Noise, const DIM: usize> SampleWithSeed<DIM> for $struct<Noise>
-            where
-                Noise: SampleWithSeed<DIM>,
+                Noise: Sample<DIM>,
             {
                 #[inline]
                 fn sample_with_seed(&$self, $point: [f32; DIM], $seed: i32) -> f32 {
@@ -90,20 +79,7 @@ macro_rules! modifier_map {
             #[cfg(feature = "nightly-simd")]
             impl<Noise, const DIM: usize, const LANES: usize> Sample<DIM, Simd<f32, LANES>> for $struct<Noise>
             where
-                Noise: SampleWithSeed<DIM, Simd<f32, LANES>>,
-                LaneCount<LANES>: SupportedLaneCount,
-            {
-                #[inline]
-                fn sample(&$self, $point: Simd<f32, LANES>) -> f32 {
-                    let $value = $self.noise.sample($point);
-                    or_else!({$({$($map_value)*})?} else { $value })
-                }
-            }
-
-            #[cfg(feature = "nightly-simd")]
-            impl<Noise, const DIM: usize, const LANES: usize> SampleWithSeed<DIM, Simd<f32, LANES>> for $struct<Noise>
-            where
-                Noise: SampleWithSeed<DIM, Simd<f32, LANES>>,
+                Noise: Sample<DIM, Simd<f32, LANES>>,
                 LaneCount<LANES>: SupportedLaneCount,
             {
                 #[inline]

--- a/src/modifiers/fbm.rs
+++ b/src/modifiers/fbm.rs
@@ -3,7 +3,7 @@ use core::simd::{LaneCount, Simd, SupportedLaneCount};
 
 use crate::{
     math::{fast_min, lerp},
-    Noise, Sample, SampleWithSeed,
+    Noise, Sample,
 };
 
 #[cfg(feature = "nightly-simd")]
@@ -47,24 +47,7 @@ impl<Noise> Fbm<Noise> {
 
 impl<Noise, const DIM: usize> Sample<DIM> for Fbm<Noise>
 where
-    Noise: SampleWithSeed<DIM>,
-{
-    #[inline]
-    fn sample(&self, point: [f32; DIM]) -> f32 {
-        let &Fbm {
-            ref noise,
-            octaves,
-            gain,
-            lacunarity,
-            fractal_bounding,
-        } = self;
-        fbm(noise, octaves, gain, lacunarity, fractal_bounding, 0, point)
-    }
-}
-
-impl<Noise, const DIM: usize> SampleWithSeed<DIM> for Fbm<Noise>
-where
-    Noise: SampleWithSeed<DIM>,
+    Noise: Sample<DIM>,
 {
     #[inline]
     fn sample_with_seed(&self, point: [f32; DIM], seed: i32) -> f32 {
@@ -81,28 +64,7 @@ where
 
 impl<Noise, const DIM: usize> Sample<DIM> for Weighted<Fbm<Noise>>
 where
-    Noise: SampleWithSeed<DIM>,
-{
-    #[inline]
-    fn sample(&self, point: [f32; DIM]) -> f32 {
-        let &Weighted {
-            fractal: Fbm {
-                ref noise,
-                octaves,
-                gain,
-                lacunarity,
-                fractal_bounding,
-            },
-            strength: weighted_strength,
-        } = self;
-
-        weighted_fbm(noise, octaves, gain, lacunarity, fractal_bounding, weighted_strength, 0, point)
-    }
-}
-
-impl<Noise, const DIM: usize> SampleWithSeed<DIM> for Weighted<Fbm<Noise>>
-where
-    Noise: SampleWithSeed<DIM>,
+    Noise: Sample<DIM>,
 {
     #[inline]
     fn sample_with_seed(&self, point: [f32; DIM], seed: i32) -> f32 {
@@ -123,26 +85,7 @@ where
 #[cfg(feature = "nightly-simd")]
 impl<Noise, const DIM: usize, const LANES: usize> Sample<DIM, Simd<f32, LANES>> for Fbm<Noise>
 where
-    Noise: SampleWithSeed<DIM, Simd<f32, LANES>>,
-    LaneCount<LANES>: SupportedLaneCount,
-{
-    #[inline]
-    fn sample(&self, point: Simd<f32, LANES>) -> f32 {
-        let &Fbm {
-            ref noise,
-            octaves,
-            gain,
-            lacunarity,
-            fractal_bounding,
-        } = self;
-        fbm_a(noise, octaves, gain, lacunarity, fractal_bounding, 0, point)
-    }
-}
-
-#[cfg(feature = "nightly-simd")]
-impl<Noise, const DIM: usize, const LANES: usize> SampleWithSeed<DIM, Simd<f32, LANES>> for Fbm<Noise>
-where
-    Noise: SampleWithSeed<DIM, Simd<f32, LANES>>,
+    Noise: Sample<DIM, Simd<f32, LANES>>,
     LaneCount<LANES>: SupportedLaneCount,
 {
     #[inline]
@@ -161,30 +104,7 @@ where
 #[cfg(feature = "nightly-simd")]
 impl<Noise, const DIM: usize, const LANES: usize> Sample<DIM, Simd<f32, LANES>> for Weighted<Fbm<Noise>>
 where
-    Noise: SampleWithSeed<DIM, Simd<f32, LANES>>,
-    LaneCount<LANES>: SupportedLaneCount,
-{
-    #[inline]
-    fn sample(&self, point: Simd<f32, LANES>) -> f32 {
-        let &Weighted {
-            fractal: Fbm {
-                ref noise,
-                octaves,
-                gain,
-                lacunarity,
-                fractal_bounding,
-            },
-            strength: weighted_strength,
-        } = self;
-
-        weighted_fbm_a(noise, octaves, gain, lacunarity, fractal_bounding, weighted_strength, 0, point)
-    }
-}
-
-#[cfg(feature = "nightly-simd")]
-impl<Noise, const DIM: usize, const LANES: usize> SampleWithSeed<DIM, Simd<f32, LANES>> for Weighted<Fbm<Noise>>
-where
-    Noise: SampleWithSeed<DIM, Simd<f32, LANES>>,
+    Noise: Sample<DIM, Simd<f32, LANES>>,
     LaneCount<LANES>: SupportedLaneCount,
 {
     #[inline]
@@ -207,7 +127,7 @@ where
 #[inline(always)]
 fn fbm<Noise, const DIM: usize>(noise: &Noise, octaves: u32, gain: f32, lacunarity: f32, fractal_bounding: f32, mut seed: i32, mut point: [f32; DIM]) -> f32
 where
-    Noise: SampleWithSeed<DIM>,
+    Noise: Sample<DIM>,
 {
     let mut sum = 0.0;
     let mut amp = fractal_bounding;
@@ -231,7 +151,7 @@ where
 #[inline(always)]
 fn fbm_a<Noise, const DIM: usize, const LANES: usize>(noise: &Noise, octaves: u32, gain: f32, lacunarity: f32, fractal_bounding: f32, mut seed: i32, mut point: Simd<f32, LANES>) -> f32
 where
-    Noise: SampleWithSeed<DIM, Simd<f32, LANES>>,
+    Noise: Sample<DIM, Simd<f32, LANES>>,
     LaneCount<LANES>: SupportedLaneCount,
 {
     let mut sum = 0.0;
@@ -252,7 +172,7 @@ where
 #[inline(always)]
 fn weighted_fbm<Noise, const DIM: usize>(noise: &Noise, octaves: u32, gain: f32, lacunarity: f32, fractal_bounding: f32, weighted_strength: f32, mut seed: i32, mut point: [f32; DIM]) -> f32
 where
-    Noise: SampleWithSeed<DIM>,
+    Noise: Sample<DIM>,
 {
     let mut sum = 0.0;
     let mut amp = fractal_bounding;
@@ -286,7 +206,7 @@ fn weighted_fbm_a<Noise, const DIM: usize, const LANES: usize>(
     mut point: Simd<f32, LANES>,
 ) -> f32
 where
-    Noise: SampleWithSeed<DIM, Simd<f32, LANES>>,
+    Noise: Sample<DIM, Simd<f32, LANES>>,
     LaneCount<LANES>: SupportedLaneCount,
 {
     let mut sum = 0.0;

--- a/src/modifiers/frequency.rs
+++ b/src/modifiers/frequency.rs
@@ -18,14 +18,14 @@ impl<const DIM: usize, Noise> Sample<DIM> for Frequency<Noise>
 where
     Noise: Sample<DIM>,
 {
-    fn sample(&self, mut point: [f32; DIM]) -> f32 {
+    fn sample_with_seed(&self, mut point: [f32; DIM], seed: i32) -> f32 {
         let frequency = self.frequency;
 
         for x in &mut point {
             *x *= frequency;
         }
 
-        self.noise.sample(point)
+        self.noise.sample_with_seed(point, seed)
     }
 }
 
@@ -35,8 +35,8 @@ where
     Noise: Sample<DIM, Simd<f32, LANES>>,
     LaneCount<LANES>: SupportedLaneCount,
 {
-    fn sample(&self, mut point: Simd<f32, LANES>) -> f32 {
+    fn sample_with_seed(&self, mut point: Simd<f32, LANES>, seed: i32) -> f32 {
         point *= Simd::splat(self.frequency);
-        self.noise.sample(point)
+        self.noise.sample_with_seed(point, seed)
     }
 }

--- a/src/modifiers/seeded.rs
+++ b/src/modifiers/seeded.rs
@@ -1,10 +1,10 @@
-use crate::{Noise, Sample, SampleWithSeed};
+use crate::{Noise, Sample};
 
 /// Wraps a noise with a seed.
 ///
-/// This structs' [`Sample`] implementation will call [`sample_with_seed`] on the base noise with `self.seed`.
+/// This structs' [`Sample`] implementation will call [`sample_with_seed`] on the base noise with `self.seed` overwriting the `seed` provided by the callee.
 ///
-/// [`sample_with_seed`]: SampleWithSeed::sample_with_seed
+/// [`sample_with_seed`]: Sample::sample_with_seed
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Seeded<Noise> {
     pub noise: Noise,
@@ -15,9 +15,9 @@ impl<N> Noise for Seeded<N> {}
 
 impl<const DIM: usize, Point, Noise> Sample<DIM, Point> for Seeded<Noise>
 where
-    Noise: SampleWithSeed<DIM, Point>,
+    Noise: Sample<DIM, Point>,
 {
-    fn sample(&self, point: Point) -> f32 {
+    fn sample_with_seed(&self, point: Point, _seed: i32) -> f32 {
         self.noise.sample_with_seed(point, self.seed)
     }
 }

--- a/src/modifiers/tileable.rs
+++ b/src/modifiers/tileable.rs
@@ -1,6 +1,6 @@
 use crate::{
     math::{cos, sin},
-    Noise, Sample, SampleWithSeed,
+    Noise, Sample,
 };
 
 use core::f32::consts::{PI, TAU};
@@ -46,15 +46,6 @@ impl<Noise> Sample<2> for Tileable<Noise>
 where
     Noise: Sample<4>,
 {
-    fn sample(&self, point: [f32; 2]) -> f32 {
-        self.noise.sample(self.map_point(point))
-    }
-}
-
-impl<Noise> SampleWithSeed<2> for Tileable<Noise>
-where
-    Noise: SampleWithSeed<4>,
-{
     fn sample_with_seed(&self, point: [f32; 2], seed: i32) -> f32 {
         self.noise.sample_with_seed(self.map_point(point), seed)
     }
@@ -64,16 +55,6 @@ where
 impl<Noise> Sample<2, f32x2> for Tileable<Noise>
 where
     Noise: Sample<4, f32x4>,
-{
-    fn sample(&self, point: f32x2) -> f32 {
-        self.noise.sample(self.map_point(point.into()).into())
-    }
-}
-
-#[cfg(feature = "nightly-simd")]
-impl<Noise> SampleWithSeed<2, f32x2> for Tileable<Noise>
-where
-    Noise: SampleWithSeed<4, f32x4>,
 {
     fn sample_with_seed(&self, point: f32x2, seed: i32) -> f32 {
         self.noise.sample_with_seed(self.map_point(point.into()).into(), seed)

--- a/src/noise.rs
+++ b/src/noise.rs
@@ -1,7 +1,18 @@
-use crate::modifiers::{Fbm, Frequency, MulSeed, Ridged, Seeded, Tileable, TriangleWave};
+use crate::{
+    modifiers::{Fbm, Frequency, MulSeed, Ridged, Seeded, Tileable, TriangleWave},
+    Sample,
+};
 
 /// Provides modifier methods for noise types.
 pub trait Noise {
+    // Samples the noise with seed 0.
+    fn sample<const DIM: usize, Point>(&self, point: Point) -> f32
+    where
+        Self: Sample<DIM, Point> + Sized,
+    {
+        self.sample_with_seed(point, 0)
+    }
+
     /// Sets a seed to be sampled with.
     ///
     /// This requires a noise that implements `SampleWithSeed`.

--- a/src/noise_fn.rs
+++ b/src/noise_fn.rs
@@ -1,4 +1,4 @@
-use crate::{Noise, Sample, SampleWithSeed};
+use crate::{Noise, Sample};
 
 /// Wraps a function to make it implement [`Sample`].
 ///
@@ -28,21 +28,12 @@ impl<const DIM: usize, Point, F> Sample<DIM, Point> for NoiseFn<F, false>
 where
     F: Fn(Point) -> f32,
 {
-    fn sample(&self, point: Point) -> f32 {
+    fn sample_with_seed(&self, point: Point, _seed: i32) -> f32 {
         self.0(point)
     }
 }
 
 impl<const DIM: usize, Point, F> Sample<DIM, Point> for NoiseFn<F, true>
-where
-    F: Fn(Point, i32) -> f32,
-{
-    fn sample(&self, point: Point) -> f32 {
-        self.0(point, 0)
-    }
-}
-
-impl<const DIM: usize, Point, F> SampleWithSeed<DIM, Point> for NoiseFn<F, true>
 where
     F: Fn(Point, i32) -> f32,
 {

--- a/src/open_simplex_2.rs
+++ b/src/open_simplex_2.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "nightly-simd")]
 use core::simd::{f32x2, f32x4};
 
-use crate::{Noise, Sample, SampleWithSeed};
+use crate::{Noise, Sample};
 
 pub(crate) trait Sealed {}
 
@@ -172,28 +172,13 @@ macro_rules! impl_improves {
                 if $improve_dim == 2 {
                     impl<N: OpenSimplexNoise> Sample<2> for $improve_struct<N> {
                         #[inline(always)]
-                        fn sample(&self, point: [f32; 2]) -> f32 {
-                            self.0.raw_sample2(self.0.$improve(point), 0)
-                        }
-                    }
-
-                    impl<N: OpenSimplexNoise> SampleWithSeed<2> for $improve_struct<N> {
-                        #[inline(always)]
                         fn sample_with_seed(&self, point: [f32; 2], seed: i32) -> f32 {
                             self.0.raw_sample2(self.0.$improve(point), seed)
                         }
                     }
 
-                    #[cfg(feature = "nightly-simd")]
-                    impl<N: OpenSimplexNoise> Sample<2, f32x2> for $improve_struct<N> {
-                        #[inline(always)]
-                        fn sample(&self, point: f32x2) -> f32 {
-                            self.0.raw_sample2a(self.0.$improve_a(point), 0)
-                        }
-                    }
-
-                    #[cfg(feature = "nightly-simd")]
-                    impl<N: OpenSimplexNoise> SampleWithSeed<2, core::simd::f32x2> for $improve_struct<N> {
+                     #[cfg(feature = "nightly-simd")]
+                    impl<N: OpenSimplexNoise> Sample<2, core::simd::f32x2> for $improve_struct<N> {
                         #[inline(always)]
                         fn sample_with_seed(&self, point: f32x2, seed: i32) -> f32 {
                             self.0.raw_sample2a(self.0.$improve_a(point), seed)
@@ -202,28 +187,13 @@ macro_rules! impl_improves {
                 } else {
                     impl<N: Sample<2>> Sample<2> for $improve_struct<N> {
                         #[inline(always)]
-                        fn sample(&self, point: [f32; 2]) -> f32 {
-                            self.0.sample(point)
-                        }
-                    }
-
-                    impl<N: SampleWithSeed<2>> SampleWithSeed<2> for $improve_struct<N> {
-                        #[inline(always)]
                         fn sample_with_seed(&self, point: [f32; 2], seed: i32) -> f32 {
                             self.0.sample_with_seed(point, seed)
                         }
                     }
 
                     #[cfg(feature = "nightly-simd")]
-                    impl<N: Sample<2, f32x2>> Sample<2, f32x2> for $improve_struct<N> {
-                        #[inline(always)]
-                        fn sample(&self, point: f32x2) -> f32 {
-                            self.0.sample(point)
-                        }
-                    }
-
-                    #[cfg(feature = "nightly-simd")]
-                    impl<N: SampleWithSeed<2, f32x2>> SampleWithSeed<2, core::simd::f32x2> for $improve_struct<N> {
+                    impl<N: Sample<2, f32x2>> Sample<2, core::simd::f32x2> for $improve_struct<N> {
                         #[inline(always)]
                         fn sample_with_seed(&self, point: f32x2, seed: i32) -> f32 {
                             self.0.sample_with_seed(point, seed)
@@ -234,14 +204,7 @@ macro_rules! impl_improves {
 
             $crate::open_simplex_2::r#if! {
                 if $improve_dim == 3 {
-                    impl<N: OpenSimplexNoise> Sample<3> for $improve_struct<N> {
-                        #[inline(always)]
-                        fn sample(&self, point: [f32; 3]) -> f32 {
-                            self.0.raw_sample3(self.0.$improve(point), 0)
-                        }
-                    }
-
-                    impl<N: OpenSimplexNoise> SampleWithSeed<3> for $improve_struct<N> {
+                     impl<N: OpenSimplexNoise> Sample<3> for $improve_struct<N> {
                         #[inline(always)]
                         fn sample_with_seed(&self, point: [f32; 3], seed: i32) -> f32 {
                             self.0.raw_sample3(self.0.$improve(point), seed)
@@ -251,27 +214,12 @@ macro_rules! impl_improves {
                     #[cfg(feature = "nightly-simd")]
                     impl<N: OpenSimplexNoise> Sample<3, f32x4> for $improve_struct<N> {
                         #[inline(always)]
-                        fn sample(&self, point: f32x4) -> f32 {
-                            self.0.raw_sample3a(self.0.$improve_a(point), 0)
-                        }
-                    }
-
-                    #[cfg(feature = "nightly-simd")]
-                    impl<N: OpenSimplexNoise> SampleWithSeed<3, f32x4> for $improve_struct<N> {
-                        #[inline(always)]
                         fn sample_with_seed(&self, point: f32x4, seed: i32) -> f32 {
                             self.0.raw_sample3a(self.0.$improve_a(point), seed)
                         }
                     }
                 } else {
                     impl<N: Sample<3>> Sample<3> for $improve_struct<N> {
-                        #[inline(always)]
-                        fn sample(&self, point: [f32; 3]) -> f32 {
-                            self.0.sample(point)
-                        }
-                    }
-
-                    impl<N: SampleWithSeed<3>> SampleWithSeed<3> for $improve_struct<N> {
                         #[inline(always)]
                         fn sample_with_seed(&self, point: [f32; 3], seed: i32) -> f32 {
                             self.0.sample_with_seed(point, seed)
@@ -280,14 +228,6 @@ macro_rules! impl_improves {
 
                     #[cfg(feature = "nightly-simd")]
                     impl<N: Sample<3, f32x4>> Sample<3, f32x4> for $improve_struct<N> {
-                        #[inline(always)]
-                        fn sample(&self, point: f32x4) -> f32 {
-                            self.0.sample(point)
-                        }
-                    }
-
-                    #[cfg(feature = "nightly-simd")]
-                    impl<N: SampleWithSeed<3, f32x4>> SampleWithSeed<3, f32x4> for $improve_struct<N> {
                         #[inline(always)]
                         fn sample_with_seed(&self, point: f32x4, seed: i32) -> f32 {
                             self.0.sample_with_seed(point, seed)
@@ -300,13 +240,6 @@ macro_rules! impl_improves {
                 if $improve_dim == 4 {
                     impl<N: OpenSimplexNoise> Sample<4> for $improve_struct<N> {
                         #[inline(always)]
-                        fn sample(&self, point: [f32; 4]) -> f32 {
-                            self.0.raw_sample4(self.0.$improve(point), 0)
-                        }
-                    }
-
-                    impl<N: OpenSimplexNoise> SampleWithSeed<4> for $improve_struct<N> {
-                        #[inline(always)]
                         fn sample_with_seed(&self, point: [f32; 4], seed: i32) -> f32 {
                             self.0.raw_sample4(self.0.$improve(point), seed)
                         }
@@ -315,27 +248,12 @@ macro_rules! impl_improves {
                     #[cfg(feature = "nightly-simd")]
                     impl<N: OpenSimplexNoise> Sample<4, f32x4> for $improve_struct<N> {
                         #[inline(always)]
-                        fn sample(&self, point: f32x4) -> f32 {
-                            self.0.raw_sample4a(self.0.$improve_a(point), 0)
-                        }
-                    }
-
-                    #[cfg(feature = "nightly-simd")]
-                    impl<N: OpenSimplexNoise> SampleWithSeed<4, f32x4> for $improve_struct<N> {
-                        #[inline(always)]
                         fn sample_with_seed(&self, point: f32x4, seed: i32) -> f32 {
                             self.0.raw_sample4a(self.0.$improve_a(point), seed)
                         }
                     }
                 } else {
                     impl<N: Sample<4>> Sample<4> for $improve_struct<N> {
-                        #[inline(always)]
-                        fn sample(&self, point: [f32; 4]) -> f32 {
-                            self.0.sample(point)
-                        }
-                    }
-
-                    impl<N: SampleWithSeed<4>> SampleWithSeed<4> for $improve_struct<N> {
                         #[inline(always)]
                         fn sample_with_seed(&self, point: [f32; 4], seed: i32) -> f32 {
                             self.0.sample_with_seed(point, seed)
@@ -344,14 +262,6 @@ macro_rules! impl_improves {
 
                     #[cfg(feature = "nightly-simd")]
                     impl<N: Sample<4, f32x4>> Sample<4, f32x4> for $improve_struct<N> {
-                        #[inline(always)]
-                        fn sample(&self, point: f32x4) -> f32 {
-                            self.0.sample(point)
-                        }
-                    }
-
-                    #[cfg(feature = "nightly-simd")]
-                    impl<N: SampleWithSeed<4, f32x4>> SampleWithSeed<4, f32x4> for $improve_struct<N> {
                         #[inline(always)]
                         fn sample_with_seed(&self, point: f32x4, seed: i32) -> f32 {
                             self.0.sample_with_seed(point, seed)
@@ -500,13 +410,6 @@ macro_rules! impl_open_simplex_noise {
 
         impl $crate::Sample<2> for $struct {
             #[inline(always)]
-            fn sample(&self, point: [f32; 2]) -> f32 {
-                self.raw_sample2(improve2(point), 0)
-            }
-        }
-
-        impl $crate::SampleWithSeed<2> for $struct {
-            #[inline(always)]
             fn sample_with_seed(&self, point: [f32; 2], seed: i32) -> f32 {
                 self.raw_sample2(improve2(point), seed)
             }
@@ -515,27 +418,12 @@ macro_rules! impl_open_simplex_noise {
         #[cfg(feature = "nightly-simd")]
         impl $crate::Sample<2, core::simd::f32x2> for $struct {
             #[inline(always)]
-            fn sample(&self, point: core::simd::f32x2) -> f32 {
-                self.raw_sample2a(improve2a(point), 0)
-            }
-        }
-
-        #[cfg(feature = "nightly-simd")]
-        impl $crate::SampleWithSeed<2, core::simd::f32x2> for $struct {
-            #[inline(always)]
             fn sample_with_seed(&self, point: core::simd::f32x2, seed: i32) -> f32 {
                 self.raw_sample2a(improve2a(point), seed)
             }
         }
 
         impl $crate::Sample<3> for $struct {
-            #[inline(always)]
-            fn sample(&self, point: [f32; 3]) -> f32 {
-                self.raw_sample3(improve3(point), 0)
-            }
-        }
-
-        impl $crate::SampleWithSeed<3> for $struct {
             #[inline(always)]
             fn sample_with_seed(&self, point: [f32; 3], seed: i32) -> f32 {
                 self.raw_sample3(improve3(point), seed)
@@ -545,14 +433,6 @@ macro_rules! impl_open_simplex_noise {
         #[cfg(feature = "nightly-simd")]
         impl $crate::Sample<3, core::simd::f32x4> for $struct {
             #[inline(always)]
-            fn sample(&self, point: core::simd::f32x4) -> f32 {
-                self.raw_sample3a(improve3a(point), 0)
-            }
-        }
-
-        #[cfg(feature = "nightly-simd")]
-        impl $crate::SampleWithSeed<3, core::simd::f32x4> for $struct {
-            #[inline(always)]
             fn sample_with_seed(&self, point: core::simd::f32x4, seed: i32) -> f32 {
                 self.raw_sample3a(improve3a(point), seed)
             }
@@ -560,28 +440,13 @@ macro_rules! impl_open_simplex_noise {
 
         impl $crate::Sample<4> for $struct {
             #[inline(always)]
-            fn sample(&self, point: [f32; 4]) -> f32 {
-                self.raw_sample4(improve4(point), 0)
-            }
-        }
-
-        impl $crate::SampleWithSeed<4> for $struct {
-            #[inline(always)]
             fn sample_with_seed(&self, point: [f32; 4], seed: i32) -> f32 {
                 self.raw_sample4(improve4(point), seed)
             }
         }
 
         #[cfg(feature = "nightly-simd")]
-        impl $crate::Sample<4, f32x4> for $struct {
-            #[inline(always)]
-            fn sample(&self, point: f32x4) -> f32 {
-                self.raw_sample4a(improve4a(point), 0)
-            }
-        }
-
-        #[cfg(feature = "nightly-simd")]
-        impl $crate::SampleWithSeed<4, core::simd::f32x4> for $struct {
+        impl $crate::Sample<4, core::simd::f32x4> for $struct {
             #[inline(always)]
             fn sample_with_seed(&self, point: core::simd::f32x4, seed: i32) -> f32 {
                 self.raw_sample4a(improve4a(point), seed)

--- a/src/sample.rs
+++ b/src/sample.rs
@@ -5,7 +5,7 @@ use crate::Noise;
 
 /// Trait for sampling noises.
 pub trait Sample<const DIM: usize, Point = [f32; DIM]>: Noise {
-    fn sample(&self, point: Point) -> f32;
+    fn sample_with_seed(&self, point: Point, seed: i32) -> f32;
 }
 
 impl<const DIM: usize, Point, N> Sample<DIM, Point> for &N
@@ -13,8 +13,8 @@ where
     N: Sample<DIM, Point>,
 {
     #[inline(always)]
-    fn sample(&self, point: Point) -> f32 {
-        N::sample(self, point)
+    fn sample_with_seed(&self, point: Point, seed: i32) -> f32 {
+        N::sample_with_seed(self, point, seed)
     }
 }
 
@@ -46,7 +46,7 @@ macro_rules! helper_trait {
 		{
 			#[inline(always)]
 			fn $fn(&self, point: impl Into<$ty>) -> f32 {
-				N::sample(self, point.into())
+				N::sample_with_seed(self, point.into(), 0)
 			}
 		}
 	};
@@ -76,8 +76,3 @@ helper_trait!(
     sample4a,
     4 as f32x4 as f32x4
 );
-
-/// Trait for sampling noises with a seed.
-pub trait SampleWithSeed<const DIM: usize, Point = [f32; DIM]>: Sample<DIM, Point> {
-    fn sample_with_seed(&self, point: Point, seed: i32) -> f32;
-}


### PR DESCRIPTION
Separating sampling in `Sample` and `SampleWithSeed` causes unexpected results once we're going to add modifiers like `add_seed` where `sample(p)` would no longer be the same as `sample_with_seed(p, 0)`.

Having this separation did give us a way of saying that a noise was seedable. So `fbm` and `seed` would only work with `SampleWithSeed` and not just any `Sample`. We lose that now. 

`sample` is still available via the `Noise` trait.