### PR TITLE
Add clamping to prevent UB from `to_int_unchecked()` on out-of-bounds floats.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- **fixed:** fix undefined behavior in SIMD sampling Perlin, Value and Cell noise in 2D and 3D (only affects `nightly-simd` feature)
+
 ## 0.8.4 (2026-04-09)
 - **added:** `&dyn Sample` now implements `Sample` and `Noise`
 - **changed:** the `std` feature now also enables the `alloc` feature

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //! <!-- feature documentation end -->
 //! <!-- crate documentation feature end -->
 #![no_std]
-#![cfg_attr(feature = "nightly-simd", feature(portable_simd))]
+#![cfg_attr(feature = "nightly-simd", feature(portable_simd), allow(clippy::incompatible_msrv))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![allow(clippy::excessive_precision, clippy::needless_late_init, clippy::too_many_arguments, clippy::approx_constant)]
 

--- a/src/math/traits.rs
+++ b/src/math/traits.rs
@@ -45,7 +45,7 @@ impl<const LANES: usize> FloorToInt for Simd<f32, LANES> {
 
     #[inline(always)]
     fn floor_to_int(self) -> Self::Output {
-        let int = unsafe { self.to_int_unchecked::<i32>() };
+        let int = simd_float_to_int_saturating(self);
         int - self.simd_ge(splat(0.0)).select(splat(0), splat(1))
     }
 }
@@ -79,8 +79,7 @@ impl<const LANES: usize> RoundToInt for Simd<f32, LANES> {
 
     #[inline(always)]
     fn round_to_int(self) -> Self::Output {
-        let f = self + self.simd_ge(splat(0.0)).select(splat(0.5), splat(-0.5));
-        unsafe { f.to_int_unchecked() }
+        simd_float_to_int_saturating(self + self.simd_ge(splat(0.0)).select(splat(0.5), splat(-0.5)))
     }
 }
 
@@ -184,6 +183,22 @@ where
     Simd::splat(value)
 }
 
+/// Acts like `float_value as i32` (rounds down and saturates when out of bounds) but on a SIMD vector.
+///
+/// Differs in that values above i32::MAX are clamped slightly below it (for efficient implementation).
+#[cfg(feature = "nightly-simd")]
+fn simd_float_to_int_saturating<const LANES: usize>(floats: Simd<f32, LANES>) -> Simd<i32, LANES> {
+    let not_nan = floats.is_nan().select(Simd::<f32, LANES>::splat(0.0), floats);
+
+    let lower_bound = const { Simd::splat(i32::MIN as f32) };
+    // i32::MAX gets rounded up when converted to f32, so we have to take a step down to stay in bounds of i32
+    let upper_bound = const { Simd::splat((i32::MAX as f32).next_down()) };
+    let clamped = not_nan.simd_clamp(lower_bound, upper_bound);
+
+    // SAFETY: we have adjusted the input to be representable as i32
+    unsafe { clamped.to_int_unchecked::<i32>() }
+}
+
 #[inline(always)]
 pub fn fast_min(a: f32, b: f32) -> f32 {
     if a < b {
@@ -200,5 +215,47 @@ pub fn fast_max(a: f32, b: f32) -> f32 {
         a
     } else {
         b
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Note: this test is meant to be run under Miri to check soundness of the `to_int_unchecked` usage.
+    #[test]
+    #[cfg(feature = "nightly-simd")]
+    fn float_to_int() {
+        use core::f32;
+        use std::simd::{f32x4, i32x4};
+
+        #[track_caller]
+        fn check_case(input: f32, expected_output: i32) {
+            assert_eq!(input as i32, expected_output, "expectation of {expected_output:?} doesn't match `{input:?} as i32`");
+            check_case_without_comparison(input, expected_output);
+        }
+        #[track_caller]
+        fn check_case_without_comparison(input: f32, expected_output: i32) {
+            // values in other lanes confirm the lanes are acting independently
+            assert_eq!(
+                simd_float_to_int_saturating(f32x4::from([input, 0.0, 1.0, 3.5])),
+                i32x4::from([expected_output, 0, 1, 3]),
+                "simd {input}"
+            );
+        }
+
+        check_case(f32::NAN, 0);
+        check_case(-f32::INFINITY, i32::MIN);
+        check_case(const { (i32::MIN as f32).next_down() }, i32::MIN);
+        check_case(const { i32::MIN as f32 }, i32::MIN);
+        check_case(const { (i32::MIN as f32).next_up() }, -2147483520);
+        check_case(const { i32::MIN as f32 }, i32::MIN);
+        check_case(-1.5, -1);
+        check_case(-0.0, 0);
+        check_case(0.0, 0);
+        check_case(1.5, 1);
+        check_case(const { (i32::MAX as f32).next_down() }, 2147483520);
+        check_case_without_comparison(const { i32::MAX as f32 }, 2147483520);
+        check_case_without_comparison(const { (i32::MAX as f32).next_up() }, 2147483520);
     }
 }

--- a/src/math/traits.rs
+++ b/src/math/traits.rs
@@ -226,8 +226,10 @@ mod tests {
     #[test]
     #[cfg(feature = "nightly-simd")]
     fn float_to_int() {
-        use core::f32;
-        use std::simd::{f32x4, i32x4};
+        use core::{
+            f32,
+            simd::{f32x4, i32x4},
+        };
 
         #[track_caller]
         fn check_case(input: f32, expected_output: i32) {

--- a/src/math/traits.rs
+++ b/src/math/traits.rs
@@ -220,6 +220,7 @@ pub fn fast_max(a: f32, b: f32) -> f32 {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "nightly-simd")]
     use super::*;
 
     /// Note: this test is meant to be run under Miri to check soundness of the `to_int_unchecked` usage.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -89,6 +89,14 @@ fn translate_doesnt_crash() {
     Sample::<4>::sample_with_seed(&Constant(0.0).translate_xyzw(0.0, 0.0, 0.0, 0.0), [0.0; 4], 0);
 }
 
+/// This test is meant to run under Miri to check for UB
+#[test]
+#[cfg(feature = "nightly-simd")]
+fn sound_when_out_of_bounds() {
+    _ = crate::ValueCubic.sample3a(std::simd::f32x4::splat(f32::INFINITY));
+    _ = crate::ValueCubic.sample3a(std::simd::f32x4::splat(i32::MAX as f32 * 10.0));
+}
+
 #[test]
 fn clamp() {
     assert_eq!(Constant(0.0).clamp(1.0, 2.0).sample2([0.0; 2]), 1.0);


### PR DESCRIPTION
Fixes #13.

I am not an expert in writing SIMD code and there may well be a better solution than this brute-force approach.